### PR TITLE
Allow watch mode to be turned off via CLI

### DIFF
--- a/src/bundle-cli.ts
+++ b/src/bundle-cli.ts
@@ -30,7 +30,7 @@ function argumentsToConfig(argumentValues: Contracts.ArgumentsValues): Contracts
 
 async function main(argumentValues: Contracts.ArgumentsValues): Promise<void> {
     const config = argumentsToConfig(argumentValues);
-    const isWatching = argumentValues.watch != null;
+    const isWatching = argumentValues.watch != null && argumentValues.watch !== "false";
     const bundler = new Launcher(config);
 
     if (argumentValues.verbosity !== Contracts.Verbosity.None && (argumentValues.entry == null || argumentValues.dest == null)) {


### PR DESCRIPTION
Currently the watch mode is set either in the config file or via a command-line arg `w`. If a glob is provided in a config file, there is currently no way to override this via the command line to switch off watch mode.

In my use-case, I have a config file which sets the "watch" value, but for building the app for prod, I want to run it with watch mode disabled. I'd like to be able to pass the `-w false` arg to the CLI to switch it off, but this does not work, since the CLI script will interpret "false" as a watch glob and still enable watch mode.

In the readme, the use of -watch with a boolean value appears to be intended, but it is not implemented that way right now.