### PR TITLE
Update Readme: Remove incorrect '--watch'  reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ scss-bundle -c scss-bundle.config.json
 ```json
 {
   "entry": "./src/main.scss",
-  "dest": "bundled.scss",
+  "dest": "./bundled.scss",
   "watch": "./src/*.scss"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@
 Bundles all SCSS imports into a single file recursively.
 
 [![Build Status](https://travis-ci.org/SimplrJS/scss-bundle.svg?branch=master)](https://travis-ci.org/SimplrJS/scss-bundle)
-[![NPM version](http://img.shields.io/npm/v/scss-bundle.svg)](https://www.npmjs.com/package/scss-bundle) 
+[![NPM version](http://img.shields.io/npm/v/scss-bundle.svg)](https://www.npmjs.com/package/scss-bundle)
 [![npm (tag)](https://img.shields.io/npm/v/scss-bundle/next.svg)](https://www.npmjs.com/package/scss-bundle)
-[![dependencies Status](https://david-dm.org/simplrjs/scss-bundle/status.svg)](https://david-dm.org/simplrjs/scss-bundle) 
+[![dependencies Status](https://david-dm.org/simplrjs/scss-bundle/status.svg)](https://david-dm.org/simplrjs/scss-bundle)
 [![devDependencies Status](https://david-dm.org/simplrjs/scss-bundle/dev-status.svg)](https://david-dm.org/simplrjs/scss-bundle?type=dev)
 
 ### Who uses `scss-bundle`
 
 A few of the projects who use the package:
 
-*   [Angular/material2](https://github.com/angular/material2)
-*   [Grassy](https://github.com/lazarljubenovic/grassy)
-*   [Copictures](https://copictures.com)
+- [Angular/material2](https://github.com/angular/material2)
+- [Grassy](https://github.com/lazarljubenovic/grassy)
+- [Copictures](https://copictures.com)
 
 ## Get started
 
@@ -62,8 +62,9 @@ $ scss-bundle -c scss-bundle.config.json
 
 ```json
 {
-    "entry": "./src/main.scss",
-    "dest": "bundled.scss"
+  "entry": "./src/main.scss",
+  "dest": "bundled.scss",
+  "watch": "./src/*.scss"
 }
 ```
 
@@ -76,7 +77,6 @@ $ scss-bundle -c scss-bundle.config.json
 | --includePaths             | includePaths         | array          | Include paths for resolving imports                               |                       |         |
 | --project, -p              | project              | string         | Project location, where `node_modules` are located.               |                       |         |
 | --ignoredImports           | ignoredImports       | array          | Ignore resolving import content by matching a regular expression. |                       |         |
-| --watch, -w                | watch                | boolean        | Watch files for changes.                                          |                       |         |
 
 `*` - Required
 
@@ -99,13 +99,12 @@ import * as path from "path";
 import { Bundler } from "scss-bundle";
 
 (async () => {
-    // Absolute project directory path.
-    const projectDirectory = path.resolve(__dirname, "./cases/tilde-import");
-    const bundler = new Bundler(undefined, projectDirectory);
-    // Relative file path to project directory path.
-    const result = await bundler.Bundle("./main.scss");
+  // Absolute project directory path.
+  const projectDirectory = path.resolve(__dirname, "./cases/tilde-import");
+  const bundler = new Bundler(undefined, projectDirectory);
+  // Relative file path to project directory path.
+  const result = await bundler.Bundle("./main.scss");
 })();
-
 ```
 
 # API
@@ -124,8 +123,8 @@ constructor(fileRegistry: FileRegistry = {}, projectDirectory?: string) {}
 
 ##### Arguments
 
-*   `fileRegistry?:` [Registry](#registry) - Dictionary of files contents by full path
-*   `projectDirectory?: string` - Absolute project location, where `node_modules` are located. Used for resolving tilde imports
+- `fileRegistry?:` [Registry](#registry) - Dictionary of files contents by full path
+- `projectDirectory?: string` - Absolute project location, where `node_modules` are located. Used for resolving tilde imports
 
 ### Methods
 
@@ -137,8 +136,8 @@ public static async Bundle(file: string, fileRegistry: Registry = {}): Promise<B
 
 ##### Arguments
 
-*   `file: string` - Main file full path
-*   `fileRegistry:` [Registry](#registry) - Dictionary of files contents by full path
+- `file: string` - Main file full path
+- `fileRegistry:` [Registry](#registry) - Dictionary of files contents by full path
 
 ##### Returns
 
@@ -152,8 +151,8 @@ public static async BundleAll(files: string[], fileRegistry: Registry = {}): Pro
 
 ##### Arguments
 
-*   `files: string[]` - Array of full path files
-*   `fileRegistry:`[Registry](#registry) - Dictionary of files contents by full path
+- `files: string[]` - Array of full path files
+- `fileRegistry:`[Registry](#registry) - Dictionary of files contents by full path
 
 ##### Returns
 
@@ -169,21 +168,21 @@ import { BundleResult } from "scss-bundle";
 
 ```typescript
 interface BundleResult {
-    imports?: BundleResult[];
-    tilde?: boolean;
-    filePath: string;
-    content?: string;
-    found: boolean;
+  imports?: BundleResult[];
+  tilde?: boolean;
+  filePath: string;
+  content?: string;
+  found: boolean;
 }
 ```
 
 ##### Properties
 
-*   `imports:` [BundleResult](#bundleresult)`[]` - File imports array
-*   `tidle?: boolean` - Used tilde import
-*   `filePath: string` - Full file path
-*   `content: string` - File content
-*   `found: boolean` - Is file found
+- `imports:` [BundleResult](#bundleresult)`[]` - File imports array
+- `tidle?: boolean` - Used tilde import
+- `filePath: string` - Full file path
+- `content: string` - File content
+- `found: boolean` - Is file found
 
 #### Registry
 
@@ -193,7 +192,7 @@ import { Registry } from "scss-bundle";
 
 ```typescript
 interface Registry {
-    [id: string]: string | undefined;
+  [id: string]: string | undefined;
 }
 ```
 


### PR DESCRIPTION
In addition, updated the Config example section of the README to include an example of the watch property and it's intended use for clarity.