### PR TITLE
Switch to pure JS Sass library from node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
         "@types/fs-extra": "^5.0.1",
         "@types/jest": "^22.2.2",
         "@types/node": "^9.6.1",
-        "@types/node-sass": "3.10.32",
         "@types/promise": "^7.1.30",
+        "@types/sass": "^1.16.0",
         "@types/yargs": "11.0.0",
         "jest": "^22.4.3",
         "jest-junit": "^6.3.0",
@@ -62,9 +62,9 @@
         "fs-extra": "^5.0.0",
         "globs": "^0.1.3",
         "lodash.debounce": "^4.0.8",
-        "node-sass": "^4.10.0",
         "pretty-bytes": "^4.0.2",
         "promise": "^8.0.1",
+        "sass": "^1.22.9",
         "yargs": "^13.1.0"
     },
     "jest": {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -4,7 +4,7 @@ import * as os from "os";
 import * as archy from "archy";
 import * as prettyBytes from "pretty-bytes";
 
-import * as nodeSass from "node-sass";
+import * as sass from "sass";
 
 import * as Contracts from "./contracts";
 import { Bundler, BundleResult, FileRegistry } from "./bundler";
@@ -90,7 +90,7 @@ export class Launcher {
 
     private async renderScss(content: string): Promise<{}> {
         return new Promise((resolve, reject) => {
-            nodeSass.render(
+            sass.render(
                 {
                     data: content,
                     importer: this.tildeImporter,
@@ -106,7 +106,7 @@ export class Launcher {
         });
     }
 
-    private tildeImporter: nodeSass.Importer = (url: string) => {
+    private tildeImporter: sass.Importer = (url: string) => {
         if (url[0] === "~") {
             const projectDirectory = this.config.ProjectDirectory ? this.config.ProjectDirectory : ".";
             const filePath = path.resolve(projectDirectory + "/node_modules", url.substr(1));


### PR DESCRIPTION
First of all, thank you for such a useful library.

This library is currently using`node-sass` and `node-sass` needs native bindings to work. Due to the native bindings, it can get quite painful to make it work in "locked-down" environments such as corporate environments behind proxy and CI environments. Due to this and other challenges,  the sass team itself has come up with pure JS Sass library and made it their default implementation. You can find more about it [here](https://sass-lang.com/install) and [here](https://sass-lang.com/dart-sass).

Starting from version 8, Angular CLI has also [switched to pure JS `sass` from `node-sass`](https://github.com/angular/angular-cli/pull/13950).

As can be seen from the code changes in this PR, it's a drop-in replacement. I hope you would consider this for merging and release. 

Thank you once again.
