### PR TITLE
Fix --dedupeGlobs cli argument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "scss-bundle",
-    "version": "3.1.0",
+    "version": "3.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "scss-bundle",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "description": "Bundling SCSS files to one bundled file.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/cli/arguments.ts
+++ b/src/cli/arguments.ts
@@ -21,7 +21,7 @@ export function resolveArguments(cmd: commander.Command, argv: string[]): Argume
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .parse(argv) as any) as Arguments;
 
-    const { config, project, entryFile, ignoreImports, includePaths, outFile, rootDir, watch, logLevel } = parsedArguments;
+    const { config, project, entryFile, ignoreImports, includePaths, outFile, rootDir, watch, logLevel, dedupeGlobs } = parsedArguments;
 
     return {
         config,
@@ -32,6 +32,7 @@ export function resolveArguments(cmd: commander.Command, argv: string[]): Argume
         outFile,
         rootDir,
         watch,
-        logLevel
+        logLevel,
+        dedupeGlobs
     };
 }


### PR DESCRIPTION
The `--dedupeGlobs` argument is ignored when specified via command line.